### PR TITLE
Subcommands to block firewall access to cf-serverd via eth0

### DIFF
--- a/share/commands/server-lock
+++ b/share/commands/server-lock
@@ -1,0 +1,12 @@
+#!/bin/bash
+# @description disable client access to Policy downloads
+
+set -e
+
+STEP="INIT"
+
+STEP="Terminating cf-serverd to stop new connections"
+pkill cf-serverd
+
+STEP="Blocking cf-serverd network access on eth0"
+iptables -A INPUT -j DROP -p tcp --destination-port 5309 -i eth0

--- a/share/commands/server-unlock
+++ b/share/commands/server-unlock
@@ -1,0 +1,9 @@
+#!/bin/bash
+# @description enable client access to Policy downloads
+
+set -e
+
+STEP="INIT"
+
+STEP="Blocking cf-serverd/cf-execd network access on eth0"
+iptables -D INPUT -j DROP -p tcp --destination-port 5309 -i eth0


### PR DESCRIPTION
No more comments since I'm biting my nails after fighting with the idiotic github client for OSX.
