### PR TITLE
Fixes #7805: Wrong case when \"rudder agent health\" looks for \"could not get an updated configuration\" string in logs

### DIFF
--- a/share/commands/agent-health
+++ b/share/commands/agent-health
@@ -50,7 +50,7 @@ then
 fi
 
 # test connection errors
-egrep "FATAL:|Fatal :|Could not get an updated configuration" "${CFE_DIR}/outputs/previous" > /dev/null
+egrep "FATAL:|Fatal :|could not get an updated configuration" "${CFE_DIR}/outputs/previous" > /dev/null
 if [ $? -ne 1 ]
 then
   echo "Connection errors in Rudder agent last run"


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7805