### PR TITLE
Fixes #7941: The display of truncated lines in rudder agent output (sometimes?) adds two spaces after | instead of one

### DIFF
--- a/share/lib/reports.awk
+++ b/share/lib/reports.awk
@@ -170,11 +170,11 @@ BEGIN {
           {
             printf "%-17.17s| ", $8;
           } else {
-            printf "%-18.18s", $8;
+            printf "%-18.18s ", $8;
           }
         }
 
-        printf " %s\n", $11
+        printf "%s\n", $11
       }
       fflush();
     }


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7941