### PR TITLE
Fixes #8317: \"rudder agent enable -s\" doesn't return an error code if it can't start the agent

### DIFF
--- a/share/commands/agent-enable
+++ b/share/commands/agent-enable
@@ -32,7 +32,8 @@ then
     $CMD
   else
     echo "Don't know how to start rudder agent." 1>&2
-    echo "Agent not started !" 1>&2
+    echo "Agent not started!" 1>&2
+	exit 2
   fi
 else
   if [ -n "${CMD}" ]


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8317