### PR TITLE
Fixes #8355: Add an output to all Rudder commands  - missing end case in agent-update

### DIFF
--- a/share/commands/agent-update
+++ b/share/commands/agent-update
@@ -37,6 +37,7 @@ while getopts "iIvdqc" opt; do
     q)
       VERBOSITY=""
       QUIET=true
+      ;;
     c)
       COLOR=""
       ;;


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8355