### PR TITLE
Fixes #9807: When in changes only mode, with no heartbeat, 'rudder agent run' outputs 'error: Rudder agent was interrupted during execution by a fatal error.'

### DIFF
--- a/share/commands/agent-run
+++ b/share/commands/agent-run
@@ -52,6 +52,15 @@ CLASSES=""
 # Ignore disable-agent flag
 FORCE=0
 
+# Report mode
+# Assume full compliance to get proper error messages
+FULL_COMPLIANCE=1
+if [ "${RUDDER_REPORT_MODE}" = 'changes-only' ] || [ "${RUDDER_REPORT_MODE}" = 'reports-disabled' ]
+then
+  FULL_COMPLIANCE=0
+fi
+
+
 UUID=$(cat /opt/rudder/etc/uuid.hive 2>/dev/null)
 [ $? -ne 0 ] && UUID="Not yet configured"
 
@@ -66,7 +75,7 @@ fi
 
 PRETTY="awk -v info=\"\${DISPLAY_INFO}\" -v full_strings=\"\${FULL_STRINGS}\" -v summary_only=\"\${SUMMARY_ONLY}\" -v quiet=\"\${QUIET}\" -v multiline=\"\${MULTILINE}\" \
             -v green=\"\${GREEN}\" -v darkgreen=\"\${DARKGREEN}\" -v red=\"\${RED}\" -v yellow=\"\${YELLOW}\" -v magenta=\"\${MAGENTA}\" -v normal=\"\${NORMAL}\" -v white=\"\${WHITE}\" -v cyan=\"\${CYAN}\" \
-            -v has_fflush=\"\${AWK_FFLUSH}\" ${AWK_OPTS} -f ${PRETTY_FILTER}"
+            -v has_fflush=\"\${AWK_FFLUSH}\" -v full_compliance=\"\${FULL_COMPLIANCE}\" ${AWK_OPTS} -f ${PRETTY_FILTER}"
 
 while getopts "iIvdqwrRmcb:D:f" opt; do
   case $opt in

--- a/share/lib/common.sh
+++ b/share/lib/common.sh
@@ -31,3 +31,16 @@ if [ -t 1 ]; then
 else
     clear_colors
 fi
+
+# Information extracted from the policies
+RUDDER_JSON="${RUDDER_VAR}/cfengine-community/inputs/rudder.json"
+PROMISES_CF="${RUDDER_VAR}/cfengine-community/inputs/promises.cf"
+
+if [ -f "${RUDDER_JSON}" ]
+then
+  RUDDER_REPORT_MODE=$(grep 'RUDDER_REPORT_MODE' "${RUDDER_JSON}" | sed 's/.*"RUDDER_REPORT_MODE":"\(.*\)",.*/\1/')
+elif [ -f "${PROMISES_CF}" ]
+  # To be compatible with old promises. This should be removed once rudder.json is everywhere.
+  RUDDER_REPORT_MODE=$(grep -E '"changes_only" *expression' "${PROMISES_CF}" | sed 's/.*strcmp("\(.*\)", "changes-only".*/\1/')
+fi
+

--- a/share/lib/reports.awk
+++ b/share/lib/reports.awk
@@ -231,7 +231,7 @@ END {
   "date +%s.%N" | getline endtime;
 
   # Check if agent run finished correctly
-  if (!end_run)
+  if (!end_run && full_compliance)
   {
     error++;
     printf "%s", red;


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9807