### PR TITLE
Fixes #12131: Agent script argument parsing failure

### DIFF
--- a/bin/rudder
+++ b/bin/rudder
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # Wrapper to call rudder commands.
-# 
+#
 # All commands are taken from $BASEDIR (/opt/rudder/share/commands).
 #
 # To add a new command, just drop it in this directory with the name <role>-<command>
@@ -20,7 +20,7 @@ RUDDER_BIN="${ABS_PATH}/`basename $0`"
 export RUDDER_BIN
 
 role_list() {
-  ls "${BASEDIR}" | sed 's/\([A-Za-z_]*\)-.*/\1/' | uniq
+  ls "${BASEDIR}" | sed 's/\([[:alpha:]_]*\)-.*/\1/' | uniq
 }
 
 usage() {
@@ -72,14 +72,14 @@ command_help() {
 }
 
 # first parameter is role parameter
-role=`echo "$1" | sed 's/[^A-Za-z_-]*//g'`
+role=`echo "$1" | sed 's/[^[:alpha:]_-]*//g'`
 if [ "${role}" = "help" ] || [ -z "${role}" ]
 then
   if [ -z "$2" ]
   then
     usage
   else
-    role=`echo "$2" | sed 's/[^A-Za-z_-]*//g'`
+    role=`echo "$2" | sed 's/[^[:alpha:]_-]*//g'`
     role_usage "${role}"
   fi
   exit 0
@@ -104,7 +104,7 @@ then
 fi
 
 # second parameter is command parameter
-command=`echo "$1" | sed 's/[^A-Za-z_-]*//g'`
+command=`echo "$1" | sed 's/[^[:alpha:]_-]*//g'`
 if [ "${command}" = "help" ] || [ "${command}" = "" ]
 then
   role_usage "${role}"
@@ -122,7 +122,7 @@ then
 fi
 
 # test if third parameter is --help
-option=`echo "$1" | sed 's/[^A-Za-z_-]*//g'`
+option=`echo "$1" | sed 's/[^[:alpha:]_-]*//g'`
 if [ "${option}" = "--help" ] || [ "${option}" = "-h" ] || [ "${option}" = "help" ]
 then
   options=`sed -ne "/#[ \t]*@man[ \t]*/s/#[ \t]*@man[ \t]*//p" "${BASEDIR}/${role}-${command}" |
@@ -139,4 +139,3 @@ fi
 
 # OK GO !
 exec "${BASEDIR}/${role}-${command}" "$@"
-


### PR DESCRIPTION
Use generic [:alpha:] character class in sed checks to make it compatible with other non-US locales.