### PR TITLE
Fixes #11824: reload-cf-serverd fails if cf-serverd not running and /sbin not in PATH

### DIFF
--- a/bin/rudder
+++ b/bin/rudder
@@ -18,7 +18,8 @@ REL_PATH=`dirname "$0"`
 ABS_PATH=`cd "${REL_PATH}" && pwd`
 RUDDER_BIN="${ABS_PATH}/`basename $0`"
 export RUDDER_BIN
-
+PATH="$PATH:/sbin:/usr/sbin"
+export PATH
 role_list() {
   ls "${BASEDIR}" | sed 's/\([[:alpha:]_]*\)-.*/\1/' | uniq
 }


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/11824