### PR TITLE
Fixes #13663: Missing spaces between key and message on rudder agent run report when using -w option

### DIFF
--- a/share/lib/reports.awk
+++ b/share/lib/reports.awk
@@ -93,7 +93,7 @@ function print_report_singleline() {
   }
 
   if (full_strings) {
-    printf "%-25s %-25s %-18s", technique, component, key;
+    printf "%-25s %-25s %-18s ", technique, component, key;
   } else {
     if (length(technique) > 25) {
       printf "%-24.24s| ", technique;


### PR DESCRIPTION
https://issues.rudder.io/issues/13663