### PR TITLE
Fixes #13821: Document that "rudder agent run -b" should not be used except if support asks

### DIFF
--- a/share/commands/agent-run
+++ b/share/commands/agent-run
@@ -27,7 +27,7 @@
 # @man +
 # @man *-R*: run the agent in completely unparsed mode, with no return code of 1 in case of error. A little faster.
 # @man +
-# @man *-b*: run the agent on a specific bundle
+# @man *-b*: run the agent on a specific bundle, this is a debug command that should generally not be used
 # @man +
 # @man *-D*: define a class for this run
 # @man +


### PR DESCRIPTION
https://issues.rudder.io/issues/13821