### PR TITLE
Fixes #13982: cf-serverd may listen on port 8080 preventing rudder-jetty from running

### DIFF
--- a/share/commands/agent-check
+++ b/share/commands/agent-check
@@ -285,5 +285,11 @@ then
   fi
 fi
 
+# Check if cf-execd ou cf-serverd is listening on 8080 on a server (see #13982)
+if [ -f /opt/rudder/etc/server-roles.d/rudder-jetty ] && LANG=C ss -lnpt | grep "LISTEN.*:8080.*cf-"
+then
+  service rudder-agent restart
+fi
+
 # Since we are in set -e there was no error here
 [ "$QUIET" = false ] && printf "${GREEN}ok${NORMAL}: Rudder agent check ran without errors.\n"


### PR DESCRIPTION
https://issues.rudder.io/issues/13982