### PR TITLE
Fixes #14692: rudder agent check does not repair policies if they are broken 

### DIFF
--- a/share/commands/agent-check
+++ b/share/commands/agent-check
@@ -229,7 +229,7 @@ empty() {
 
 check_and_fix_inputs() {
   # if file is absent or empty there have been a problem with update
-  if empty "${CFE_DIR}/inputs/common/1.0/update.cf" || empty "${CFE_DIR}/inputs/failsafe.cf" || empty "${CFE_DIR}/inputs/promises.cf" || ${CFE_BIN_DIR}/cf-promises -f failsafe.cf | grep error > /dev/null
+  if empty "${CFE_DIR}/inputs/common/1.0/update.cf" || empty "${CFE_DIR}/inputs/failsafe.cf" || empty "${CFE_DIR}/inputs/promises.cf" || ! ${CFE_BIN_DIR}/cf-promises -f failsafe.cf > /dev/null
   then
     printf "ERROR: There was an error during promises update. Reseting to initial promises and updating..."
     rm -rf ${CFE_DIR}/inputs/*
@@ -247,7 +247,7 @@ check_and_fix_inputs() {
   fi
 
   # Ensure main promises are not broken, and clean ncf cache and force a new download if so
-  if ${CFE_BIN_DIR}/cf-promises | grep error > /dev/null
+  if ! ${CFE_BIN_DIR}/cf-promises > /dev/null
   then
     rm -rf ${CFE_DIR}/state/ncf-exclude-cache-*
     rm -f ${CFE_DIR}/inputs/rudder_promises_updated


### PR DESCRIPTION
https://issues.rudder.io/issues/14692

Replacing previous PR: https://github.com/Normation/rudder-agent/pull/209
