### PR TITLE
Fixes #15460: Rudder agent disable command has a -s option, that is not parsed

### DIFF
--- a/share/commands/agent-disable
+++ b/share/commands/agent-disable
@@ -15,7 +15,7 @@
 
 QUIET=false
 
-while getopts "qc" opt; do
+while getopts "qcs" opt; do
   case $opt in
     s)
       STOP=y


### PR DESCRIPTION
https://issues.rudder.io/issues/15460