### PR TITLE
Fixes #15535: rudder server trigger-policy-generation/reload-groups, etc outputs curl error if apache2 is stopped

### DIFF
--- a/share/commands/server-trigger-policy-generation
+++ b/share/commands/server-trigger-policy-generation
@@ -26,7 +26,7 @@ while getopts "iIvdc" opt; do
 done
 
 # check if the API is available
-api_result=$(filtered_api_call "${API_URL}/api/latest/system/status" "${TOKEN}" "GET" "" "${DISPLAY_COMMAND}")
+api_result=$(filtered_api_call "${API_URL}/api/latest/system/status" "${TOKEN}" "GET" "" "${DISPLAY_COMMAND}" 2>/dev/null)
 api_code=$?
 
 if [ ${api_code} -eq 0 ]


### PR DESCRIPTION
https://issues.rudder.io/issues/15535