### PR TITLE
Fixes #16355: In https reporting mode, the agent outputs html raw text at the end of output

### DIFF
--- a/share/lib/report.sh
+++ b/share/lib/report.sh
@@ -50,7 +50,7 @@ compress_and_sign() {
 
     # Try to send it.
     # If it fails, it will be sent later by the agent
-    curl --tlsv1.2 ${CERTIFICATE_OPTION} --fail --silent --proxy '' --user "${DAVUSER}:${DAVPW}" --upload-file "${ready_file}" https://${SERVER}/reports/
+    curl --tlsv1.2 ${CERTIFICATE_OPTION} --fail --silent --proxy '' --user "${DAVUSER}:${DAVPW}" --upload-file "${ready_file}" https://${SERVER}/reports/ >/dev/null
     if [ $? -eq 0 ]; then
         # Remove temp file
         rm "${ready_file}"


### PR DESCRIPTION
https://issues.rudder.io/issues/16355