### PR TITLE
Fixes #16703: Method "exist_or_restore" in rudder agent check outputs an error message if the backup doesn't exist

### DIFF
--- a/share/commands/agent-check
+++ b/share/commands/agent-check
@@ -93,7 +93,7 @@ exist_or_restore() {
   file_name=$(basename ${file_path})
   if [ ! -f "${file_path}" ] || [ ! -s "${file_path}" ]; then
     if [ -d "${BACKUP_DIR}" ] && [ "${RESET}" = "false" ]; then
-      last_backup=$(ls -1 ${BACKUP_DIR}${file_name}-* | sort | tail -n1 || true)
+      last_backup=$(ls -1 ${BACKUP_DIR}${file_name}-* 2> /dev/null | sort | tail -n1 || true)
       if [ "${last_backup}" != "" ]; then
         [ "$QUIET" = false ] && printf "INFO: The file '${file_path}' does not exist. The lastest backup '${last_backup}' will be recovered..."
         ${CP_A} "${last_backup}" "${file_path}" >/dev/null


### PR DESCRIPTION
https://issues.rudder.io/issues/16703