### PR TITLE
Fixes #17283: Only errors preventing the agent from properly running should set an error return code

### DIFF
--- a/share/lib/reports.awk
+++ b/share/lib/reports.awk
@@ -465,7 +465,7 @@ END {
   printf "%s%-80.80s%s\n", white, padding, normal;
 
   # Set return code
-  if (run_error+audit_error+enforce_error != 0) {
+  if (run_error != 0) {
     exit 1;
   }
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/17283