### PR TITLE
Fixes #17424: Fail password confirmation in BCrypt lead to an user with empty password in file

### DIFF
--- a/share/commands/server-create-user
+++ b/share/commands/server-create-user
@@ -10,6 +10,9 @@
 
 . "${BASEDIR}/../lib/common.sh"
 
+set -o pipefail
+set -e
+
 USERFILE="/opt/rudder/etc/rudder-users.xml"
 USER="admin"
 


### PR DESCRIPTION
https://issues.rudder.io/issues/17424