### PR TITLE
Patch to use rudder on a read-only / system (move /var/rudder and /opt/rudder to another directories)

### DIFF
--- a/share/commands/agent-check
+++ b/share/commands/agent-check
@@ -122,7 +122,7 @@ exist_or_restore() {
 # Compare agent certificate UID and agent UUID (return shell boolean)
 compare_uuid() {
   UUID=$(cat "${UUID_FILE}")
-  SUBJECT=$(openssl x509 -in /opt/rudder/etc/ssl/agent.cert -noout -subject | sed 's/.*UID *= *\([^,]*\)\(,.*\)*/\1/')
+  SUBJECT=$(openssl x509 -in ${RUDDER_DIR}/etc/ssl/agent.cert -noout -subject | sed 's/.*UID *= *\([^,]*\)\(,.*\)*/\1/')
   [ "${UUID}" = "${SUBJECT}" ]
 }
 # CFEngine keys must be present with a certificate and have proper access rights
@@ -142,11 +142,11 @@ check_and_fix_cfengine_keys() {
     fi
   fi
   # Agent must have a certificate with a subject that match agent uuid
-  if ! exist_or_restore /opt/rudder/etc/ssl/agent.cert || ! compare_uuid
+  if ! exist_or_restore ${RUDDER_DIR}/etc/ssl/agent.cert || ! compare_uuid
   then
     [ "$QUIET" = false ] && printf "INFO: Agent certificate is missing, creating it..."
     UUID=$(cat "${UUID_FILE}")
-    openssl req -new -batch -sha256 -key ${CFE_DIR}/ppkeys/localhost.priv -out /opt/rudder/etc/ssl/agent.cert -passin "pass:Cfengine passphrase" -x509 -days 3650 -extensions agent_cert -config /opt/rudder/etc/ssl/openssl-agent.cnf -subj "/CN=${UUID}/UID=${UUID}"
+    openssl req -new -batch -sha256 -key ${CFE_DIR}/ppkeys/localhost.priv -out ${RUDDER_DIR}/etc/ssl/agent.cert -passin "pass:Cfengine passphrase" -x509 -days 3650 -extensions agent_cert -config ${RUDDER_DIR}/etc/ssl/openssl-agent.cnf -subj "/CN=${UUID}/UID=${UUID}"
     [ "$QUIET" = false ] && echo " Done"
   fi
   # Agent certificate UID must match agent UUID
@@ -254,7 +254,7 @@ check_and_fix_rudder_uuid() {
   if ! exist_or_restore "${UUID_FILE}"
   then
     [ "$QUIET" = false ] && printf "INFO: The UUID of the node does not exist and no backup exist. A new one will be generated..."
-    /opt/rudder/bin/rudder-uuidgen > ${UUID_FILE}
+    ${RUDDER_DIR}/bin/rudder-uuidgen > ${UUID_FILE}
     [ "$QUIET" = false ] && echo " Done"
   fi
 
@@ -266,9 +266,9 @@ check_and_fix_rudder_uuid() {
     [ "$QUIET" = false ] && printf "${YELLOW}WARNING${NORMAL}: Creating a new UUID for Rudder as the existing one is invalid..."
     # Keep a backup of UUID even if it is not valid
     mkdir -p "${BACKUP_DIR}"
-    cp -f /opt/rudder/etc/uuid.hive ${BACKUP_DIR}/uuid-`date +%Y%m%d`.hive
+    cp -f ${RUDDER_DIR}/etc/uuid.hive ${BACKUP_DIR}/uuid-`date +%Y%m%d`.hive
     # Generate a new one
-    /opt/rudder/bin/rudder-uuidgen > ${UUID_FILE}
+    ${RUDDER_DIR}/bin/rudder-uuidgen > ${UUID_FILE}
     echo " Done."
   fi
   
@@ -297,7 +297,7 @@ check_and_fix_inputs() {
 # Inventory must have been sent less than 3 days ago
 check_and_fix_inventory() {
   # age in hours
-  inventory_age=$(perl -e '(@i) = stat($ARGV[0]); printf "%ld\n", (time-$i[9])/3600' /var/rudder/tmp/inventory_sent)
+  inventory_age=$(perl -e '(@i) = stat($ARGV[0]); printf "%ld\n", (time-$i[9])/3600' ${RUDDER_VAR}/tmp/inventory_sent)
   # 72 hours = 3 days
   if [ "${inventory_age}" -gt 72 ]
   then
@@ -325,7 +325,7 @@ check_space() {
 check_varspace_or_exit() {
   # check max space available for databases and stop Rudder if there is a risk
   if [ -f ${RUDDER_SERVER_ROLES}/rudder-ldap ]; then
-    check_space /var/rudder/ldap/ 98
+    check_space ${RUDDER_VAR}/ldap/ 98
   fi
 
   if [ -f ${RUDDER_SERVER_ROLES}/rudder-reports ]; then

--- a/share/commands/agent-diff
+++ b/share/commands/agent-diff
@@ -20,7 +20,7 @@
 canonify() {
   printf "$1" | tr -c '[A-Za-z0-9_]' '_'
 }
-BASE_PATH="/var/rudder/modified-files/"
+BASE_PATH="${RUDDER_VAR}/modified-files/"
 BASE_NAME=""
 
 while getopts "l:n:d:" opt; do

--- a/share/commands/agent-disable
+++ b/share/commands/agent-disable
@@ -37,7 +37,7 @@ while getopts "qcsk" opt; do
   esac
 done
 
-touch /opt/rudder/etc/disable-agent
+touch ${RUDDER_DIR}/etc/disable-agent
 
 [ $? -ne 0 ] && printf "${RED}error${NORMAL}: Rudder agent could not be disabled.\n" && exit 1
 

--- a/share/commands/agent-enable
+++ b/share/commands/agent-enable
@@ -31,7 +31,7 @@ while getopts "sqc" opt; do
   esac
 done
 
-rm -f /opt/rudder/etc/disable-agent
+rm -f ${RUDDER_DIR}/etc/disable-agent
 
 [ $? -ne 0 ] && printf "${RED}error${NORMAL}: Rudder agent could not be enabled.\n" && exit 1
 

--- a/share/commands/agent-factory-reset
+++ b/share/commands/agent-factory-reset
@@ -80,31 +80,31 @@ fi
 # Backup essential files
 [ "$VERBOSE" = true ] && echo "Making a backup copy of essential files into /var/backups/rudder"
 mkdir -p /var/backups/rudder
-cp -f /opt/rudder/etc/uuid.hive /var/backups/rudder/uuid.hive-$(date +%Y%m%d) 2>/dev/null
-cp -f /var/rudder/cfengine-community/policy_server.dat /var/backups/rudder/policy_server.dat-$(date +%Y%m%d) 2>/dev/null
-cp -af /var/rudder/cfengine-community/ppkeys/ /var/backups/rudder/ppkeys-$(date +%Y%m%d) 2>/dev/null
-cp -f /opt/rudder/etc/ssl/agent.cert /var/backups/rudder/agent.cert-$(date +%Y%m%d) 2>/dev/null
+cp -f ${RUDDER_DIR}/etc/uuid.hive /var/backups/rudder/uuid.hive-$(date +%Y%m%d) 2>/dev/null
+cp -f ${RUDDER_VAR}/cfengine-community/policy_server.dat /var/backups/rudder/policy_server.dat-$(date +%Y%m%d) 2>/dev/null
+cp -af ${RUDDER_VAR}/cfengine-community/ppkeys/ /var/backups/rudder/ppkeys-$(date +%Y%m%d) 2>/dev/null
+cp -f ${RUDDER_DIR}/etc/ssl/agent.cert /var/backups/rudder/agent.cert-$(date +%Y%m%d) 2>/dev/null
 
 # reset policies
 ${RUDDER_BIN} agent reset
 
 # - remove ppkeys (check will recreate them)
 [ "$VERBOSE" = true ] && echo "Removing the agent keys..."
-rm -f /var/rudder/cfengine-community/ppkeys/localhost*
-rm -f /opt/rudder/etc/ssl/agent.cert
+rm -f ${RUDDER_VAR}/cfengine-community/ppkeys/localhost*
+rm -f ${RUDDER_DIR}/etc/ssl/agent.cert
 
 # - remove all trust
 [ "$VERBOSE" = true ] && echo "Untrusting all other systems..."
-rm -f /var/rudder/cfengine-community/ppkeys/*
+rm -f ${RUDDER_VAR}/cfengine-community/ppkeys/*
 
 # - remove uuid (check will recreate it)
 [ "$VERBOSE" = true ] && echo "Removing UUID..."
-rm -f /opt/rudder/etc/uuid.hive
+rm -f ${RUDDER_DIR}/etc/uuid.hive
 
 # - remove old inventory
 [ "$VERBOSE" = true ] && echo "Removing old inventory..."
-rm -rf /opt/rudder/var/fusioninventory/*
-rm -rf /var/rudder/tmp/inventory/*
+rm -rf ${RUDDER_DIR}/var/fusioninventory/*
+rm -rf ${RUDDER_VAR}/tmp/inventory/*
 
 # - check and repair everything missing (keys, uuid, reset, update, inventory ...)
 ${RUDDER_BIN} agent check -f -r ${OPTS}

--- a/share/commands/agent-health
+++ b/share/commands/agent-health
@@ -6,12 +6,12 @@
 # @man +
 # @man *-n*: run in nrpe mode, print a single line and return 0,1 or 2
 # @man  put this line in your nrpe.cfg to use it
-# @man  command[check_rudder]=/opt/rudder/bin/rudder agent health -n
+# @man  command[check_rudder]=${RUDDER_DIR}/bin/rudder agent health -n
 
 . "${BASEDIR}/../lib/common.sh"
 
-CFE_DIR=/var/rudder/cfengine-community
-CFE_DISABLE_FILE=/opt/rudder/etc/disable-agent
+CFE_DIR=${RUDDER_VAR}/cfengine-community
+CFE_DISABLE_FILE=${RUDDER_DIR}/etc/disable-agent
 
 NRPE=
 

--- a/share/commands/agent-history
+++ b/share/commands/agent-history
@@ -12,7 +12,7 @@
 . "${BASEDIR}/../lib/common.sh"
 . "${BASEDIR}/../lib/cfengine_parsing.sh"
 
-BASE_PATH="/var/rudder/cfengine-community/outputs"
+BASE_PATH="${RUDDER_VAR}/cfengine-community/outputs"
 # Display 25 lines by default
 max=25
 

--- a/share/commands/agent-info
+++ b/share/commands/agent-info
@@ -22,25 +22,25 @@ while getopts "v" opt; do
   esac
 done
 
-CERT_CRE=$(openssl x509 -startdate -noout -in /opt/rudder/etc/ssl/agent.cert | cut -d= -f2)
+CERT_CRE=$(openssl x509 -startdate -noout -in ${RUDDER_DIR}/etc/ssl/agent.cert | cut -d= -f2)
 [ $? -ne 0 ] && CERT_CRE="Not yet configured"
-CERT_EXP=$(openssl x509 -enddate -noout -in /opt/rudder/etc/ssl/agent.cert | cut -d= -f2)
+CERT_EXP=$(openssl x509 -enddate -noout -in ${RUDDER_DIR}/etc/ssl/agent.cert | cut -d= -f2)
 [ $? -ne 0 ] && CERT_EXP="Not yet configured"
-CERT_FINGERPRINT=$(openssl x509 -in /opt/rudder/etc/ssl/agent.cert -noout -fingerprint -sha1 | cut -d= -f2)
+CERT_FINGERPRINT=$(openssl x509 -in ${RUDDER_DIR}/etc/ssl/agent.cert -noout -fingerprint -sha1 | cut -d= -f2)
 [ $? -ne 0 ] && CERT_FINGERPRINT="Not yet configured"
 KEY_HASH=$(${RUDDER_DIR}/bin/cf-promises --show-vars | grep "sys.key_digest" | awk '{print $2}')
 [ $? -ne 0 ] && KEY_HASH="Not yet configured"
 
-POLICY=$(cat /var/rudder/cfengine-community/policy_server.dat 2>/dev/null)
+POLICY=$(cat ${RUDDER_VAR}/cfengine-community/policy_server.dat 2>/dev/null)
 [ $? -ne 0 ] && POLICY="Not yet configured"
 
-POLICY_FETCHED=$(modification_time /var/rudder/cfengine-community/last_successful_inputs_update 2> /dev/null)
+POLICY_FETCHED=$(modification_time ${RUDDER_VAR}/cfengine-community/last_successful_inputs_update 2> /dev/null)
 [ $? -ne 0 ] && POLICY_FETCHED="Not yet updated" || POLICY_FETCHED=$(echo "${POLICY_FETCHED}" | cut -d'.' -f1)
 
-INVENTORY_SENT=$(modification_time /var/rudder/tmp/inventory_sent 2> /dev/null)
+INVENTORY_SENT=$(modification_time ${RUDDER_VAR}/tmp/inventory_sent 2> /dev/null)
 [ $? -ne 0 ] && INVENTORY_SENT="Not yet sent" || INVENTORY_SENT=$(echo "${INVENTORY_SENT}" | cut -d'.' -f1)
 
-ROLES=$(ls -m /opt/rudder/etc/server-roles.d/ 2>/dev/null)
+ROLES=$(ls -m ${RUDDER_DIR}/etc/server-roles.d/ 2>/dev/null)
 if [ $? -ne 0 ]; then
   ROLES="rudder-agent"
 else
@@ -49,10 +49,10 @@ fi
 
 if [ "${UUID}" != "root" ]
 then
-  if [ -d /var/rudder/share ]
+  if [ -d ${RUDDER_VAR}/share ]
   then
     ROLES="${ROLES}, rudder-relay"
-  elif [ -d /var/rudder/inventories/incoming ]
+  elif [ -d ${RUDDER_VAR}/inventories/incoming ]
   then
     ROLES="${ROLES}, rudder-relay (not registered)"
   fi
@@ -66,7 +66,7 @@ echo "Key hash: ${KEY_HASH}"
 echo "Certificate creation: ${CERT_CRE}"
 echo "Certificate expiration: ${CERT_EXP}"
 echo "Certificate fingerprint: ${CERT_FINGERPRINT}"
-[ "${VERBOSE}" = "true" ] && echo "Certificate:" && cat /opt/rudder/etc/ssl/agent.cert
+[ "${VERBOSE}" = "true" ] && echo "Certificate:" && cat ${RUDDER_DIR}/etc/ssl/agent.cert
 echo "Policy server: ${POLICY}"
 echo "Roles: ${ROLES}"
 if [ -n "${RUDDER_REPORT_MODE}" ]
@@ -74,13 +74,13 @@ then
   echo "Report mode: ${RUDDER_REPORT_MODE}"
 fi
 echo "Run interval: ${AGENT_RUN_INTERVAL} min"
-if [ -e /opt/rudder/etc/disable-agent ]; then
-  echo "Agent is disabled since $(modification_time /opt/rudder/etc/disable-agent)"
+if [ -e ${RUDDER_DIR}/etc/disable-agent ]; then
+  echo "Agent is disabled since $(modification_time ${RUDDER_DIR}/etc/disable-agent)"
 else
   echo "Agent is enabled"
 fi
-if [ -e /opt/rudder/etc/force-audit-agent ]; then
-  echo "Agent is forced in audit mode since $(modification_time /opt/rudder/etc/force-audit-agent)"
+if [ -e ${RUDDER_DIR}/etc/force-audit-agent ]; then
+  echo "Agent is forced in audit mode since $(modification_time ${RUDDER_DIR}/etc/force-audit-agent)"
 else
   echo "Agent is not forced in audit mode"
 fi

--- a/share/commands/agent-inventory
+++ b/share/commands/agent-inventory
@@ -32,7 +32,7 @@
 bootstrap_check
 
 # We cannnot start an inventory in bootstrap policies
-if cmp -s "/var/rudder/cfengine-community/inputs/failsafe.cf" "/opt/rudder/share/bootstrap-promises/failsafe.cf"
+if cmp -s "${RUDDER_VAR}/cfengine-community/inputs/failsafe.cf" "${RUDDER_DIR}/share/bootstrap-promises/failsafe.cf"
 then
   >&2 echo "Agent is currently in bootstrap policies, cannot run an inventory. Please download initial policies from the server with command \"rudder agent update\" first. If problem persists, use \"rudder agent check\" for diagnostic"
   exit 1
@@ -61,7 +61,7 @@ do
   fi
 done
 
-if [ ${FORCE} -eq 0 ] && [ -e /opt/rudder/etc/disable-inventory ]; then
+if [ ${FORCE} -eq 0 ] && [ -e ${RUDDER_DIR}/etc/disable-inventory ]; then
   printf "${RED}error${NORMAL}: The inventory is currently disabled.\n"
   exit 1
 fi

--- a/share/commands/agent-log
+++ b/share/commands/agent-log
@@ -38,7 +38,7 @@
 UPDATE=false
 UPDATE_OPTIONS=""
 # default logfile is last run
-BASE_PATH="/var/rudder/cfengine-community/outputs"
+BASE_PATH="${RUDDER_VAR}/cfengine-community/outputs"
 LOGFILE="${BASE_PATH}/previous"
 
 while getopts "wrRcl:n:d:eE" opt; do

--- a/share/commands/agent-policy-server
+++ b/share/commands/agent-policy-server
@@ -9,7 +9,7 @@
 
 . "${BASEDIR}/../lib/common.sh"
 
-SERVER_FILE="/var/rudder/cfengine-community/policy_server.dat"
+SERVER_FILE="${RUDDER_VAR}/cfengine-community/policy_server.dat"
 
 CURRENT=$(cat ${SERVER_FILE} 2>/dev/null)
 [ $? -ne 0 ] && CURRENT="Not yet configured"

--- a/share/commands/agent-reset
+++ b/share/commands/agent-reset
@@ -55,35 +55,35 @@ done
 # Try to remove everything that can block
 # - restore initial promises
 [ "$VERBOSE" = true ] && echo "Restoring initial policies..."
-rm -rf /var/rudder/cfengine-community/inputs/*
+rm -rf ${RUDDER_VAR}/cfengine-community/inputs/*
 # - remove ncf
-rm -rf /var/rudder/ncf/common/*
-rm -rf /var/rudder/ncf/local/*
+rm -rf ${RUDDER_VAR}/ncf/common/*
+rm -rf ${RUDDER_VAR}/ncf/local/*
 
 # - remove state
 [ "$VERBOSE" = true ] && echo "Resetting internal agent state..."
-rm -rf /var/rudder/cfengine-community/state/*
-rm -f /var/rudder/cfengine-community/*.lmdb
+rm -rf ${RUDDER_VAR}/cfengine-community/state/*
+rm -f ${RUDDER_VAR}/cfengine-community/*.lmdb
 
 # - remove locks
 [ "$VERBOSE" = true ] && echo "Removing all agent locks..."
-rm -f /var/rudder/cfengine-community/*lock
+rm -f ${RUDDER_VAR}/cfengine-community/*lock
 
 # - remove the disable status
 [ "$VERBOSE" = true ] && echo "Enabling the agent if needed..."
-rm -f /opt/rudder/etc/disable-agent
+rm -f ${RUDDER_DIR}/etc/disable-agent
 
 # - bootstrap agent (but not on root server without initial promises)
-if [ -f "${RUDDER_VAR}/cfengine-community/policy_server.dat" ] && [ "${UUID}" != "root" -o -d /opt/rudder/share/initial-promises/ ]
+if [ -f "${RUDDER_VAR}/cfengine-community/policy_server.dat" ] && [ "${UUID}" != "root" -o -d ${RUDDER_DIR}/share/initial-promises/ ]
 then
   if [ "${UUID}" != "root" ]
   then
     # Bootstrap promises: the update should do the rest
-    cp /opt/rudder/share/bootstrap-promises/* /var/rudder/cfengine-community/inputs/
+    cp ${RUDDER_DIR}/share/bootstrap-promises/* ${RUDDER_VAR}/cfengine-community/inputs/
 
   else
     # Initial promises: the update should copy ncf
-    cp -r /opt/rudder/share/initial-promises/* /var/rudder/cfengine-community/inputs/
+    cp -r ${RUDDER_DIR}/share/initial-promises/* ${RUDDER_VAR}/cfengine-community/inputs/
   fi
   # Update to make sure we have working policies
   [ "$VERBOSE" = true ] && echo "Getting initial policies..."

--- a/share/commands/agent-run
+++ b/share/commands/agent-run
@@ -147,7 +147,7 @@ done
 
 printf "${VERSION}\nNode uuid: ${UUID}\n"
 
-if [ ${FORCE} -eq 0 ] && [ -e /opt/rudder/etc/disable-agent ]; then
+if [ ${FORCE} -eq 0 ] && [ -e ${RUDDER_DIR}/etc/disable-agent ]; then
   printf "\n${RED}error${NORMAL}: The Rudder agent is currently disabled. You can enable it with 'rudder agent enable'.\n" 1>&2
   exit 1
 fi
@@ -180,7 +180,7 @@ fi
 if [ "${OUTPUT_LOG}" = "true" ]; then
   # keep same name structure as cf-execd
   logfile=$(echo "cf_$(get_hostname)__$(LANG=C date +%s)_$(LANG=C date +"%a %b %e %H %M %S %Y")_0" | sed 's/[^a-zA-Z0-9]/_/g')
-  logdir=/var/rudder/cfengine-community/outputs
+  logdir=${RUDDER_VAR}/cfengine-community/outputs
   touch "${logdir}/${logfile}"
   chmod 600 "${logdir}/${logfile}"
   log_outputs="tee ${logdir}/${logfile}"

--- a/share/commands/agent-server-keys-reset
+++ b/share/commands/agent-server-keys-reset
@@ -42,8 +42,8 @@ fi
 
 # - remove all known keys
 [ "$VERBOSE" = true ] && echo "Removing all known keys..."
-rm -f /var/rudder/cfengine-community/ppkeys/root*
-rm -f /var/rudder/cfengine-community/ppkeys/policy_server_hash
+rm -f ${RUDDER_VAR}/cfengine-community/ppkeys/root*
+rm -f ${RUDDER_VAR}/cfengine-community/ppkeys/policy_server_hash
 
 [ "$VERBOSE" = true ] && echo "Resetting policies..."
 ${RUDDER_BIN} agent reset

--- a/share/commands/agent-set-force-audit
+++ b/share/commands/agent-set-force-audit
@@ -25,7 +25,7 @@ while getopts "qc" opt; do
   esac
 done
 
-touch /opt/rudder/etc/force-audit-agent
+touch ${RUDDER_DIR}/etc/force-audit-agent
 
 [ $? -ne 0 ] && printf "${RED}error${NORMAL}: Rudder agent could not be be forced in audit mode.\n" && exit 1
 

--- a/share/commands/agent-unset-force-audit
+++ b/share/commands/agent-unset-force-audit
@@ -23,7 +23,7 @@ while getopts "qc" opt; do
   esac
 done
 
-rm -f /opt/rudder/etc/force-audit-agent
+rm -f ${RUDDER_DIR}/etc/force-audit-agent
 
 [ $? -ne 0 ] && printf "${RED}error${NORMAL}: Rudder force audit mode could not be disabled.\n" && exit 1
 

--- a/share/commands/directive-list
+++ b/share/commands/directive-list
@@ -11,10 +11,10 @@
 
 . "${BASEDIR}/../lib/common.sh"
 
-BASE_PATH="/var/rudder/cfengine-community/inputs"
+BASE_PATH="${RUDDER_VAR}/cfengine-community/inputs"
 
 # Sanity check: if folder is empty then we are in bootstrap mode
-NB_FILE_IN_FOLDER=$(find /var/rudder/cfengine-community/inputs -type f | wc -l)
+NB_FILE_IN_FOLDER=$(find ${RUDDER_VAR}/cfengine-community/inputs -type f | wc -l)
 if [ ${NB_FILE_IN_FOLDER} -eq 0 ]
 then
   echo "Agent is still in bootstrap mode - there are no directives on this node"

--- a/share/commands/directive-run
+++ b/share/commands/directive-run
@@ -36,7 +36,7 @@
 
 . "${BASEDIR}/../lib/common.sh"
 
-BASE_PATH="/var/rudder/cfengine-community/inputs"
+BASE_PATH="${RUDDER_VAR}/cfengine-community/inputs"
 SERVER_VERSION=$(rudder_json_value 'SERVER_VERSION' | cut -d. -f1,2)
 
 major_compare "${SERVER_VERSION}" "6.0"

--- a/share/commands/relay-reload
+++ b/share/commands/relay-reload
@@ -30,9 +30,9 @@ while getopts "qciIvdp" opt; do
       clear_colors
       ;;
     p)
-      if [ -f /var/rudder/lib/ssl/allnodescerts.pem ]; then chgrp rudder /var/rudder/lib/ssl/allnodescerts.pem; fi
-      if [ -f /var/rudder/lib/ssl/allnodescerts.pem ] && type restorecon >/dev/null 2>&1; then restorecon /var/rudder/lib/ssl/allnodescerts.pem; fi
-      if [ -f /var/rudder/lib/relay/nodeslist.json ]; then chown rudder-relayd /var/rudder/lib/relay/nodeslist.json; fi
+      if [ -f ${RUDDER_VAR}/lib/ssl/allnodescerts.pem ]; then chgrp rudder ${RUDDER_VAR}/lib/ssl/allnodescerts.pem; fi
+      if [ -f ${RUDDER_VAR}/lib/ssl/allnodescerts.pem ] && type restorecon >/dev/null 2>&1; then restorecon ${RUDDER_VAR}/lib/ssl/allnodescerts.pem; fi
+      if [ -f ${RUDDER_VAR}/lib/relay/nodeslist.json ]; then chown rudder-relayd ${RUDDER_VAR}/lib/relay/nodeslist.json; fi
       # Needed in case it was not running
       # Only do it in -p as it should not be done in the general case which is used by systemd to reload the service
       if ! systemctl is-active rudder-relayd >/dev/null; then

--- a/share/commands/relay-start
+++ b/share/commands/relay-start
@@ -23,7 +23,7 @@ while getopts "qc" opt; do
   esac
 done
 
-if [ -s /var/rudder/lib/ssl/allnodescerts.pem ]; then chgrp rudder /var/rudder/lib/ssl/allnodescerts.pem; fi
-if [ -f /var/rudder/lib/relay/nodeslist.json ]; then chown rudder-relayd /var/rudder/lib/relay/nodeslist.json; fi
+if [ -s ${RUDDER_VAR}/lib/ssl/allnodescerts.pem ]; then chgrp rudder ${RUDDER_VAR}/lib/ssl/allnodescerts.pem; fi
+if [ -f ${RUDDER_VAR}/lib/relay/nodeslist.json ]; then chown rudder-relayd ${RUDDER_VAR}/lib/relay/nodeslist.json; fi
 service_action "rudder-relayd" "start"
 exit $?

--- a/share/commands/server-create-user
+++ b/share/commands/server-create-user
@@ -13,7 +13,7 @@
 set -o pipefail
 set -e
 
-USERFILE="/opt/rudder/etc/rudder-users.xml"
+USERFILE="${RUDDER_DIR}/etc/rudder-users.xml"
 USER="admin"
 
 while getopts "u:" opt; do

--- a/share/commands/server-health
+++ b/share/commands/server-health
@@ -8,7 +8,7 @@
 # @man +
 # @man *-n*: run in nrpe mode, print a single line and return 0,1 or 2
 # @man  put this line in your nrpe.cfg to use it
-# @man  command[check_rudder_server]=/opt/rudder/bin/rudder server health -n
+# @man  command[check_rudder_server]=${RUDDER_DIR}/bin/rudder server health -n
 
 . "${BASEDIR}/../lib/common.sh"
 
@@ -55,16 +55,16 @@ if [ $ERRORS -ne 0 ]; then
 fi
 
 # Check credentials
-if [ ! -f /opt/rudder/etc/rudder-web.properties ]
+if [ ! -f ${RUDDER_DIR}/etc/rudder-web.properties ]
 then
-  echo "/opt/rudder/etc/rudder-web.properties is missing"
+  echo "${RUDDER_DIR}/etc/rudder-web.properties is missing"
   exit 2
 fi
 
-# Get how many access credentials we got for LDAP and SQL in /opt/rudder/etc/rudder-web.properties
+# Get how many access credentials we got for LDAP and SQL in ${RUDDER_DIR}/etc/rudder-web.properties
 # (should have 2 for each, user and password)
-LDAP_CREDENTIALS=$(grep -c -E "^ldap.auth(dn|pw)[ \t]*=" /opt/rudder/etc/rudder-web.properties || true)
-SQL_CREDENTIALS=$(grep -c -E "^rudder.jdbc.(username|password)[ \t]*=" /opt/rudder/etc/rudder-web.properties || true)
+LDAP_CREDENTIALS=$(grep -c -E "^ldap.auth(dn|pw)[ \t]*=" ${RUDDER_DIR}/etc/rudder-web.properties || true)
+SQL_CREDENTIALS=$(grep -c -E "^rudder.jdbc.(username|password)[ \t]*=" ${RUDDER_DIR}/etc/rudder-web.properties || true)
 TOTAL_CREDENTIALS=$((LDAP_CREDENTIALS+SQL_CREDENTIALS))
 
 if [ ${TOTAL_CREDENTIALS} -ne 4 ]
@@ -74,16 +74,16 @@ then
 fi
 
 # Get the database access credentials from the rudder-web.properties file
-LDAP_USER="$(grep -E '^ldap.authdn[ \t]*=' /opt/rudder/etc/rudder-web.properties | cut -d "=" -f 2-)"
-LDAP_PASSWORD="$(grep -E '^ldap.authpw[ \t]*=' /opt/rudder/etc/rudder-web.properties | cut -d "=" -f 2-)"
-LDAP_SERVER="$(grep -E '^ldap.host[ \t]*=' /opt/rudder/etc/rudder-web.properties | cut -d '=' -f 2-)"
-LDAP_PORT="$(grep -E '^ldap.port[ \t]*=' /opt/rudder/etc/rudder-web.properties | cut -d '=' -f 2-)"
+LDAP_USER="$(grep -E '^ldap.authdn[ \t]*=' ${RUDDER_DIR}/etc/rudder-web.properties | cut -d "=" -f 2-)"
+LDAP_PASSWORD="$(grep -E '^ldap.authpw[ \t]*=' ${RUDDER_DIR}/etc/rudder-web.properties | cut -d "=" -f 2-)"
+LDAP_SERVER="$(grep -E '^ldap.host[ \t]*=' ${RUDDER_DIR}/etc/rudder-web.properties | cut -d '=' -f 2-)"
+LDAP_PORT="$(grep -E '^ldap.port[ \t]*=' ${RUDDER_DIR}/etc/rudder-web.properties | cut -d '=' -f 2-)"
 
-SQL_USER="$(grep -E '^rudder.jdbc.username[ \t]*=' /opt/rudder/etc/rudder-web.properties | cut -d "=" -f 2-)"
-SQL_PASSWORD="$(grep -E '^rudder.jdbc.password[ \t]*=' /opt/rudder/etc/rudder-web.properties | cut -d "=" -f 2-)"
-SQL_SERVER="$(grep -E '^rudder.jdbc.url[ \t]*=' /opt/rudder/etc/rudder-web.properties | cut -d '=' -f 2- | sed 's%^.*://\(.*\):\(.*\)/.*$%\1%')"
-SQL_PORT="$(grep -E '^rudder.jdbc.url[ \t]*=' /opt/rudder/etc/rudder-web.properties | cut -d '=' -f 2- | sed 's%^.*://\(.*\):\(.*\)/.*$%\2%')"
-SQL_DATABASE="$(grep -E '^rudder.jdbc.url[ \t]*=' /opt/rudder/etc/rudder-web.properties | cut -d '=' -f 2- | sed 's%^.*://.*:.*/\(.*\)$%\1%')"
+SQL_USER="$(grep -E '^rudder.jdbc.username[ \t]*=' ${RUDDER_DIR}/etc/rudder-web.properties | cut -d "=" -f 2-)"
+SQL_PASSWORD="$(grep -E '^rudder.jdbc.password[ \t]*=' ${RUDDER_DIR}/etc/rudder-web.properties | cut -d "=" -f 2-)"
+SQL_SERVER="$(grep -E '^rudder.jdbc.url[ \t]*=' ${RUDDER_DIR}/etc/rudder-web.properties | cut -d '=' -f 2- | sed 's%^.*://\(.*\):\(.*\)/.*$%\1%')"
+SQL_PORT="$(grep -E '^rudder.jdbc.url[ \t]*=' ${RUDDER_DIR}/etc/rudder-web.properties | cut -d '=' -f 2- | sed 's%^.*://\(.*\):\(.*\)/.*$%\2%')"
+SQL_DATABASE="$(grep -E '^rudder.jdbc.url[ \t]*=' ${RUDDER_DIR}/etc/rudder-web.properties | cut -d '=' -f 2- | sed 's%^.*://.*:.*/\(.*\)$%\1%')"
 
 export PGPASSWORD="${SQL_PASSWORD}"
 

--- a/share/commands/server-trigger-policy-generation
+++ b/share/commands/server-trigger-policy-generation
@@ -42,7 +42,7 @@ then
   fi
 else
   echo "Web interface is down - requested a policy generation at its restart"
-  touch /opt/rudder/etc/trigger-policy-generation
+  touch ${RUDDER_DIR}/etc/trigger-policy-generation
 fi
 
 

--- a/share/commands/server-upgrade-techniques
+++ b/share/commands/server-upgrade-techniques
@@ -1,7 +1,7 @@
 #!/bin/bash
 # @description Upgrade techniques in the configuration repository from the packaged ones
-# @man This command will replace the techniques in /var/rudder/configuration-repository/techniques
-# @man by the techniques found in /opt/rudder/share/techniques which is installed by rudder-technique package.
+# @man This command will replace the techniques in ${RUDDER_VAR}/configuration-repository/techniques
+# @man by the techniques found in ${RUDDER_DIR}/share/techniques which is installed by rudder-technique package.
 # @man The upgrade can take care of user defined changes.
 # @man This command creates an update branch "rudder_update" with the content of current techniques first time is it run
 # @man +
@@ -34,7 +34,7 @@ PARENT_COMMIT=""
 SET_OPTION=false
 KEY_OPTION=""
 VALUE_OPTION=""
-CONFIGURATION_FILE=/opt/rudder/etc/rudder.conf
+CONFIGURATION_FILE=${RUDDER_DIR}/etc/rudder.conf
 
 AUTO_UPDATE_TECHNIQUE=false
 DURING_UPGRADE=false
@@ -47,8 +47,8 @@ function usage()
 {
   echo "rudder server upgrade-techniques"
   echo "upgrade techniques in the configuration repository from the packaged ones"
-  echo "This command will replace the techniques in /var/rudder/configuration-repository/techniques"
-  echo "by the techniques found in /opt/rudder/share/techniques which is installed by rudder-technique package."
+  echo "This command will replace the techniques in ${RUDDER_VAR}/configuration-repository/techniques"
+  echo "by the techniques found in ${RUDDER_DIR}/share/techniques which is installed by rudder-technique package."
   echo "The upgrade can take care of user defined changes."
   echo "This command creates an update branch rudder_update with the content of current techniques first time is it run"
   echo ""
@@ -242,8 +242,8 @@ fi
 
 
 
-REPO="/var/rudder/configuration-repository"
-BASE="/opt/rudder/share/techniques"
+REPO="${RUDDER_VAR}/configuration-repository"
+BASE="${RUDDER_DIR}/share/techniques"
 UPDATE_BRANCH="rudder_update"
 
 cd "${REPO}"
@@ -256,12 +256,12 @@ then
     if git checkout "${UPDATE_BRANCH}"
     then
       cp -a "${BASE}"/* techniques/
-      /opt/rudder/bin/rudder-fix-repository-permissions
+      ${RUDDER_DIR}/bin/rudder-fix-repository-permissions
       git add techniques/
       git commit -q -m "${TAG_MESSAGE} Standard technique upgrade from version ${package_version} on $(date)"
       git checkout master
       git merge "${UPDATE_BRANCH}"
-      /opt/rudder/bin/rudder-fix-repository-permissions
+      ${RUDDER_DIR}/bin/rudder-fix-repository-permissions
       # TODO Now's a good time for a user shell
       rudder server reload-techniques
     else
@@ -302,7 +302,7 @@ then
   fi
   git branch "${UPDATE_BRANCH}" "${PARENT_COMMIT}"
   # Fix permissions
-  /opt/rudder/bin/rudder-fix-repository-permissions
+  ${RUDDER_DIR}/bin/rudder-fix-repository-permissions
   exit 0
 fi
 
@@ -317,7 +317,7 @@ then
     read a
   fi
   cp -a "${BASE}"/* techniques/
-  /opt/rudder/bin/rudder-fix-repository-permissions
+  ${RUDDER_DIR}/bin/rudder-fix-repository-permissions
   git add techniques/
   git reset HEAD techniques/**/resources/*
   git commit -q -m "${TAG_MESSAGE} Forced technique upgrade from version ${package_version} on $(date)"
@@ -334,7 +334,7 @@ then
     rudder server reload-techniques
   else
     # webapp is down, so we have to touch file for reloading after reboot
-    touch /opt/rudder/etc/force_technique_reload
+    touch ${RUDDER_DIR}/etc/force_technique_reload
   fi
   echo "Techniques have been updated, and update branch set to current state of the Techniques"
 fi

--- a/share/lib/api_call.sh
+++ b/share/lib/api_call.sh
@@ -52,7 +52,7 @@ full_api_call() {
     url=`_get_conf "${conf}" "url"`
     if [ -z "${url}" ]
     then
-      host=`cut -d: -f1 /var/rudder/cfengine-community/policy_server.dat 2>/dev/null`
+      host=`cut -d: -f1 ${RUDDER_VAR}/cfengine-community/policy_server.dat 2>/dev/null`
       [ -z "${host}" ] && host="localhost"
       url="https://${host}/rudder"
     fi

--- a/share/lib/common.sh
+++ b/share/lib/common.sh
@@ -87,7 +87,7 @@ init_commands() {
     if [ -e /bin/vzps ]; then # we have vzps
       PS_COMMAND="/bin/vzps -E 0"
     else # use rudder provided vzps
-      PS_COMMAND="/opt/rudder/bin/vzps.py -E 0"
+      PS_COMMAND="${RUDDER_DIR}/bin/vzps.py -E 0"
     fi
   elif [ -n "${ns}" ]; then # we have namespaces
     # the sed is here to prepend a fake user field that is removed by the -o option (it is never used)
@@ -142,14 +142,14 @@ modification_time() {
 # Check that a bootstrap is necessary
 bootstrap_check() {
   # create folder if it doesn't exist
-  if [ ! -d "/var/rudder/cfengine-community/inputs" ]
+  if [ ! -d "${RUDDER_VAR}/cfengine-community/inputs" ]
   then
-    mkdir -p /var/rudder/cfengine-community/inputs
+    mkdir -p ${RUDDER_VAR}/cfengine-community/inputs
   fi
 
-  if [ "$(ls -A /var/rudder/cfengine-community/inputs)" = "" ]
+  if [ "$(ls -A ${RUDDER_VAR}/cfengine-community/inputs)" = "" ]
   then
-    cp /opt/rudder/share/bootstrap-promises/* /var/rudder/cfengine-community/inputs/
+    cp ${RUDDER_DIR}/share/bootstrap-promises/* ${RUDDER_VAR}/cfengine-community/inputs/
     rudder agent update
   fi
 }
@@ -215,7 +215,7 @@ fi
 [ "${AGENT_RUN_INTERVAL}" = "" ] && AGENT_RUN_INTERVAL=5
 
 # Rudder uuid
-UUID=$(cat /opt/rudder/etc/uuid.hive 2>/dev/null)
+UUID=$(cat ${RUDDER_DIR}/etc/uuid.hive 2>/dev/null)
 [ $? -ne 0 ] && UUID="Not yet configured"
 
 if [ "${RUDDER_REPORT_MODE}" = "changes-only" ] || [ "${RUDDER_REPORT_MODE}" = "reports-disabled" ]
@@ -235,7 +235,7 @@ else
   CERTIFICATE_OPTION="--insecure"
 fi
 
-TOKEN="$([ -f /var/rudder/run/api-token ] && cat /var/rudder/run/api-token 2>/dev/null)"
+TOKEN="$([ -f ${RUDDER_VAR}/run/api-token ] && cat ${RUDDER_VAR}/run/api-token 2>/dev/null)"
 
 # detect OS family
 OS_FAMILY=`uname -s`

--- a/share/lib/report.sh
+++ b/share/lib/report.sh
@@ -6,15 +6,15 @@ if [ -f "${RUDDER_JSON}" ]; then
 fi
 
 SERVER=$(cut -d: -f1 "${RUDDER_VAR}/cfengine-community/policy_server.dat")
-TMP_REPORTS_DIR="/var/rudder/tmp/reports/"
-REPORTS_DIR="/var/rudder/reports/ready/"
+TMP_REPORTS_DIR="${RUDDER_VAR}/tmp/reports/"
+REPORTS_DIR="${RUDDER_VAR}/reports/ready/"
 
 mkdir -p "${TMP_REPORTS_DIR}"
 mkdir -p "${REPORTS_DIR}"
 
 # The key to use for signature
-PRIVKEY="/var/rudder/cfengine-community/ppkeys/localhost.priv"
-CERT="/opt/rudder/etc/ssl/agent.cert"
+PRIVKEY="${RUDDER_VAR}/cfengine-community/ppkeys/localhost.priv"
+CERT="${RUDDER_DIR}/etc/ssl/agent.cert"
 
 # Private key passphrase
 PASSPHRASE="Cfengine passphrase"


### PR DESCRIPTION
I want to use rudder on a read-only rootfs embedded device (/var/rudder is readonly) so I need to move /var/rudder to another writable directory.

Changes made :
  - replace static /var/rudder/ by ${RUDDER_VAR}
  - replace static /opt/rudder/ by ${RUDDER_DIR}