### PR TITLE
Fixes #19563: /opt/rudder/share/lib/common.sh fails when the api-token file does not exist

### DIFF
--- a/share/lib/common.sh
+++ b/share/lib/common.sh
@@ -244,7 +244,11 @@ else
   CERTIFICATE_OPTION="--insecure"
 fi
 
-TOKEN="$([ -f ${RUDDER_VAR}/run/api-token ] && cat ${RUDDER_VAR}/run/api-token 2>/dev/null)"
+TOKEN=""
+if [ -f ${RUDDER_VAR}/run/api-token ]
+then
+  TOKEN=$(cat ${RUDDER_VAR}/run/api-token 2>/dev/null)
+fi
 
 # detect OS family
 OS_FAMILY=`uname -s`


### PR DESCRIPTION
https://issues.rudder.io/issues/19563