### PR TITLE
Fixes #19583: Inventory fails because rudder-client fails because it needs /opt/rudder/etc/agent.conf

### DIFF
--- a/share/lib/common.sh
+++ b/share/lib/common.sh
@@ -185,10 +185,12 @@ parse_directive() {
   name=$(echo "${_name}"| sed 's/^"\(.*\)"$/\1/')
 }
 
-# read one key of agent.conf
+# read one key of agent.conf if file exists
 agent_conf() {
-  key="$1"
-  sed -n "/^${key} *=/s/^${key} *= *//p" "${AGENT_CONFIGURATION}"
+  if [ -f ${AGENT_CONFIGURATION} ]; then
+    key="$1"
+    sed -n "/^${key} *=/s/^${key} *= *//p" "${AGENT_CONFIGURATION}"
+  fi
 }
 
 


### PR DESCRIPTION
https://issues.rudder.io/issues/19583