### PR TITLE
Fixes #22498: server-create-user uses old role attribte in place of new permissions one

### DIFF
--- a/share/commands/server-create-user
+++ b/share/commands/server-create-user
@@ -53,7 +53,7 @@ fi
 # bcrypt (12 cost)
 hash=$(htpasswd -n${PASS_OPT}BC 12 "" ${ADMIN_PASSWORD}| tr -d ':\n')
 
-details="<user name=\"${USER}\" password=\"${hash}\" role=\"administrator\" />"
+details="<user name=\"${USER}\" password=\"${hash}\" permissions=\"administrator\" />"
 sed -i "/^[[:space:]]*<\/authentication>/i ${details}" "${USERFILE}"
 
 echo "User '${USER}' added, restarting the Rudder server"


### PR DESCRIPTION
https://issues.rudder.io/issues/22498