### PR TITLE
Fixes #24620: Add a warning in "rudder agent info" when cf-execd is stopped

### DIFF
--- a/share/commands/agent-info
+++ b/share/commands/agent-info
@@ -75,6 +75,14 @@ if ! [ -e ${RUDDER_DIR}/etc/disable-agent ]; then
   fi
 fi
 
+if ! systemctl -q is-active "rudder-cf-execd"; then
+    echo ""
+    echo "Warning: the 'rudder-cf-execd' service is stopped so the agent is"
+    echo "         not scheduled automatically. Enable and start it with:"
+    echo ""
+    echo "           systemctl enable -s rudder-cf-execd"
+fi
+
 printf "\n${WHITE}General${NORMAL}\n"
 echo "           Hostname: $(get_hostname)"
 echo "               UUID: ${UUID}"


### PR DESCRIPTION
https://issues.rudder.io/issues/24620