### PR TITLE
Fixes #27039: (Subtask) rudder agent check complains “egrep: warning: egrep is obsolescent; using grep -E”

### DIFF
--- a/share/commands/agent-check
+++ b/share/commands/agent-check
@@ -224,7 +224,7 @@ check_and_fix_cfengine_processes() {
   # A standard kill won't kill them, so the -9 is necessary to make sure they are stopped
   # They will be restarted by the check below, if the disable file is not set
   # List the cf-execd processes running (without the path, they can be run manually)
-  CF_EXECD_RUNNING=`${PS_COMMAND} | egrep "(${RUDDER_DIR}|${CFE_BIN})/cf-execd" | sed -e '/grep/d' | cat`
+  CF_EXECD_RUNNING=`${PS_COMMAND} | grep -E "(${RUDDER_DIR}|${CFE_BIN})/cf-execd" | sed -e '/grep/d' | cat`
   NB_CF_EXECD_RUNNING=`echo "${CF_EXECD_RUNNING}" | sed -e '/^$/d' | wc -l`
   if [ ${NB_CF_EXECD_RUNNING} -gt 6 ]; then
     [ "$QUIET" = false ] && printf "${YELLOW}WARNING${NORMAL}: Too many instance of Rudder cf-execd processes running. Killing them..."
@@ -241,7 +241,7 @@ check_and_fix_cfengine_processes() {
   fi
 
   # List the CFEngine processes running
-  CF_PROCESS_RUNNING=`${PS_COMMAND} | egrep "(${RUDDER_DIR}|${CFE_DIR})/bin/cf-(agent|execd)" | cat`
+  CF_PROCESS_RUNNING=`${PS_COMMAND} | grep -E "(${RUDDER_DIR}|${CFE_DIR})/bin/cf-(agent|execd)" | cat`
   # Count the number of processes running, filtering empty lines
   NB_CF_PROCESS_RUNNING=`echo "${CF_PROCESS_RUNNING}" | sed -e '/^$/d' | wc -l`
 
@@ -308,7 +308,7 @@ check_and_fix_rudder_uuid() {
 
   # UUID is valid only if it has been generetaed by uuidgen or if it is set to 'root' for policy server
   REGEX=`x="[a-f0-9][a-f0-9][a-f0-9][a-f0-9]" && echo "$x$x-$x-$x-$x-$x$x$x"`
-  CHECK_UUID=`egrep "^$REGEX|^root" ${UUID_FILE} | wc -l`
+  CHECK_UUID=`grep -E "^$REGEX|^root" ${UUID_FILE} | wc -l`
   # If the UUID is not valid, regenerate it
   if [ ${CHECK_UUID} -ne 1 ]; then
     [ "$QUIET" = false ] && printf "${YELLOW}WARNING${NORMAL}: Creating a new UUID for Rudder as the existing one is invalid..."
@@ -398,7 +398,7 @@ check_varspace_or_exit() {
     fi
     if [ -f ${RUDDER_SERVER_ROLES}/rudder-reports ]; then
       # Try with systemd
-      POSTGRESQL_SERVICE_NAME=$(systemctl list-unit-files --type service | awk -F'.' '{print $1}' | egrep "^postgresql-?[0-9]*$" | tail -n 1)
+      POSTGRESQL_SERVICE_NAME=$(systemctl list-unit-files --type service | awk -F'.' '{print $1}' | grep -E "^postgresql-?[0-9]*$" | tail -n 1)
 
       # If nothing try with chkconfig (sles 12 only: postgresql is properly managed by systemd but cannot be detected with the line above)
       if [ -z "${POSTGRESQL_SERVICE_NAME}" ] && ! type chkconfig >/dev/null 2>/dev/null ; then

--- a/share/commands/agent-health
+++ b/share/commands/agent-health
@@ -40,7 +40,7 @@ then
 fi
 
 # test policy server value if it's not an ip
-if ! egrep "^[0-9.]+$|^[0-9a-fA-F:]+$" "${CFE_DIR}/policy_server.dat">/dev/null; then
+if ! grep -E "^[0-9.]+$|^[0-9a-fA-F:]+$" "${CFE_DIR}/policy_server.dat">/dev/null; then
   if type getent >/dev/null 2>/dev/null; then
     cut -d: -f1 "${CFE_DIR}/policy_server.dat" | xargs getent hosts > /dev/null
   else
@@ -67,7 +67,7 @@ fi
 # otherwise we are before the first agent run or in bootstrap promises
 if [ -e "${CFE_DIR}/outputs/previous" ]
 then
-  egrep "FATAL:|Fatal :|could not get an updated configuration" "${CFE_DIR}/outputs/previous" > /dev/null
+  grep -E "FATAL:|Fatal :|could not get an updated configuration" "${CFE_DIR}/outputs/previous" > /dev/null
   if [ $? -ne 1 ]
   then
     echo "Connection errors in Rudder agent last run"

--- a/share/lib/common.sh
+++ b/share/lib/common.sh
@@ -111,7 +111,7 @@ init_commands() {
     fi
   elif [ -n "${ns}" ]; then # we have namespaces
     # the sed is here to prepend a fake user field that is removed by the -o option (it is never used)
-    PS_COMMAND="eval ps --no-header -e -O utsns | egrep '^[[:space:]]*[[:digit:]]*[[:space:]]+${ns}' | sed 's/^/user /'"
+    PS_COMMAND="eval ps --no-header -e -O utsns | grep -E '^[[:space:]]*[[:digit:]]*[[:space:]]+${ns}' | sed 's/^/user /'"
   else # standard unix
     PS_COMMAND="ps -ef"
   fi


### PR DESCRIPTION
https://issues.rudder.io/issues/27039